### PR TITLE
fix(auth): add navigation listener after login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **Auth**: Login page now navigates to Dashboard after successful authentication.
+
 ### Added
 - **Financial Modeling**:
   - Implemented Domain Entities: `SaaSMetrics`, `IncomeStatement`, `CashFlow`, `UnitEconomics`, `MonthlyFinancialRecord`, `FinancialScenario`.

--- a/lib/features/auth/presentation/pages/login_page.dart
+++ b/lib/features/auth/presentation/pages/login_page.dart
@@ -3,6 +3,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:saas_metrics/features/auth/presentation/pages/sign_up_page.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:saas_metrics/features/auth/presentation/providers/auth_provider.dart';
+import 'package:saas_metrics/features/financial_modeling/presentation/pages/dashboard_page.dart';
 
 
 class LoginPage extends ConsumerStatefulWidget {
@@ -59,6 +60,18 @@ class _LoginPageState extends ConsumerState<LoginPage> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final authState = ref.watch(authProvider);
+
+    // Listen for auth state changes and navigate on successful login
+    ref.listen<AsyncValue<dynamic>>(authProvider, (previous, next) {
+      next.whenData((token) {
+        if (token != null && token.isValid) {
+          Navigator.of(context).pushAndRemoveUntil(
+            MaterialPageRoute(builder: (_) => const DashboardPage()),
+            (route) => false,
+          );
+        }
+      });
+    });
 
     return Scaffold(
       appBar: AppBar(


### PR DESCRIPTION
## Summary
Fixes login navigation issue where the app stayed on the login page after successful authentication.

## Problem
After inputting email and password, nothing happened. The main page only showed after restarting the debug run.

**Root Cause**: `MaterialApp.home` only sets the *initial* route—it doesn't trigger navigation when state changes during runtime. Since `LoginPage` was pushed onto the navigation stack from `OnboardingPage`, the app stayed there even after auth state updated.

## Solution
Added a `ref.listen` in `LoginPage` that watches for auth state changes. When login succeeds and a valid token is present, it navigates to `DashboardPage` using `pushAndRemoveUntil` to clear the entire navigation stack.

## Changes
- Added import for `DashboardPage` in `login_page.dart`
- Added `ref.listen` callback in `build()` to reactively navigate after login
- Updated `CHANGELOG.md`