### PR TITLE
feat: Implement first-run onboarding and dashboard simulation feedback (#6)

### DIFF
--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -8,6 +8,7 @@ import 'package:saas_metrics/features/auth/presentation/pages/sign_up_page.dart'
 import 'package:saas_metrics/features/auth/presentation/providers/auth_provider.dart';
 import 'package:saas_metrics/features/financial_modeling/presentation/pages/dashboard_page.dart';
 import 'package:saas_metrics/features/onboarding/presentation/pages/onboarding_page.dart';
+import 'package:saas_metrics/features/onboarding/presentation/providers/onboarding_provider.dart';
 
 part 'app_router.g.dart';
 
@@ -22,15 +23,22 @@ abstract class AppRoutes {
 /// Provider for a listenable that notifies the router of auth state changes.
 class RouterListenable extends ChangeNotifier {
   RouterListenable(Ref ref) {
-    _subscription = ref.listen(authProvider, (previous, next) {
+    _authSubscription = ref.listen(authProvider, (previous, next) {
+      notifyListeners();
+    });
+    _onboardingSubscription = ref.listen(onboardingProvider, (previous, next) {
       notifyListeners();
     });
   }
 
-  late final ProviderSubscription _subscription;
+  late final ProviderSubscription _authSubscription;
+  late final ProviderSubscription _onboardingSubscription;
 
-  void disposeSubscription() {
-    _subscription.close();
+  @override
+  void dispose() {
+    _authSubscription.close();
+    _onboardingSubscription.close();
+    super.dispose();
   }
 }
 
@@ -38,31 +46,51 @@ class RouterListenable extends ChangeNotifier {
 @riverpod
 GoRouter appRouter(Ref ref) {
   final authState = ref.watch(authProvider);
+  final onboardingState = ref.watch(onboardingProvider);
   final listenable = RouterListenable(ref);
-  ref.onDispose(listenable.disposeSubscription);
+  ref.onDispose(listenable.dispose);
 
   return GoRouter(
     initialLocation: AppRoutes.login,
     refreshListenable: listenable,
     debugLogDiagnostics: true,
     redirect: (context, state) {
+      if (authState.isLoading || onboardingState.isLoading) {
+        return null;
+      }
+
       final isAuthenticated =
-          authState.whenOrNull(
-            data: (token) => token != null && token.isValid,
-          ) ??
-          false;
+          authState.value != null && authState.value!.isValid;
+
+      final hasSeenOnboarding = onboardingState.value ?? false;
 
       final isAuthRoute =
           state.matchedLocation == AppRoutes.login ||
           state.matchedLocation == AppRoutes.signUp ||
           state.matchedLocation == AppRoutes.onboarding;
 
-      // Redirect unauthenticated users trying to access protected routes
-      if (!isAuthenticated && !isAuthRoute) {
-        return AppRoutes.login;
+      // 1. Unauthenticated users
+      if (!isAuthenticated) {
+        // Force onboarding on first run
+        if (!hasSeenOnboarding) {
+          if (state.matchedLocation != AppRoutes.onboarding) {
+            return AppRoutes.onboarding;
+          }
+          return null;
+        }
+
+        // If they have seen onboarding but are on the onboarding page, go to login
+        if (state.matchedLocation == AppRoutes.onboarding) {
+          return AppRoutes.login;
+        }
+
+        // Protect internal routes
+        if (!isAuthRoute) {
+          return AppRoutes.login;
+        }
       }
 
-      // Redirect authenticated users away from auth routes to dashboard
+      // 2. Authenticated users
       if (isAuthenticated && isAuthRoute) {
         return AppRoutes.dashboard;
       }

--- a/lib/core/router/app_router.g.dart
+++ b/lib/core/router/app_router.g.dart
@@ -52,4 +52,4 @@ final class AppRouterProvider
   }
 }
 
-String _$appRouterHash() => r'9bc27d7392108943cacba02fdc675d4eced3d13b';
+String _$appRouterHash() => r'ece056cc4d1d7da8d8329ff240ac38f02d0e2fc6';

--- a/lib/features/financial_modeling/presentation/pages/dashboard_page.dart
+++ b/lib/features/financial_modeling/presentation/pages/dashboard_page.dart
@@ -2,16 +2,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_adaptive_scaffold/flutter_adaptive_scaffold.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
 
 import 'package:saas_metrics/core/router/app_router.dart';
 import 'package:saas_metrics/features/financial_modeling/domain/entities/monthly_financial_record.dart';
-
-import 'package:intl/intl.dart';
-
 import '../../presentation/providers/financial_projections_provider.dart';
 import '../../../auth/presentation/providers/auth_provider.dart';
 import '../widgets/kpi_card.dart';
 import '../widgets/revenue_chart.dart';
+import '../widgets/simulation_dialog.dart';
 
 class DashboardPage extends ConsumerStatefulWidget {
   const DashboardPage({super.key});
@@ -35,256 +34,322 @@ class _DashboardPageState extends ConsumerState<DashboardPage> {
           'SaaS Financial Dashboard',
           style: TextStyle(fontWeight: FontWeight.bold),
         ),
-      ),
-      body: Row(
-        children: [
-          if (isDesktop)
-            NavigationRail(
-              extended: Breakpoints.large.isActive(context),
-              destinations: const [
-                NavigationRailDestination(
-                  icon: Icon(Icons.dashboard_outlined),
-                  selectedIcon: Icon(Icons.dashboard),
-                  label: Text('Dashboard'),
-                ),
-                // NavigationRail requires at least 2 destinations.
-                // Dummy hidden destination to satisfy API.
-                NavigationRailDestination(
-                  icon: Opacity(opacity: 0.0, child: Icon(Icons.circle)),
-                  label: Text(''),
-                  disabled: true,
-                ),
-              ],
-              selectedIndex: 0,
-              trailing: Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.all(16.0),
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.end,
-                    children: [
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.end,
-                        children: [
-                          if (Breakpoints.large.isActive(context))
-                            TextButton.icon(
-                              onPressed: () => _signOut(context, ref),
-                              icon: const Icon(Icons.logout, color: Colors.red),
-                              label: const Text(
-                                'Sign Out',
-                                style: TextStyle(color: Colors.red),
-                              ),
-                            )
-                          else
-                            IconButton(
-                              onPressed: () => _signOut(context, ref),
-                              icon: const Icon(Icons.logout),
-                              tooltip: 'Sign Out',
-                              color: Colors.red,
-                            ),
-                        ],
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            ),
-          Expanded(
-            child: projectionsAsync.when(
-              data: (records) {
-                if (records.isEmpty) {
-                  return Center(
-                    key: const ValueKey('empty_state'),
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        const Icon(
-                          Icons.analytics_outlined,
-                          size: 64,
-                          color: Colors.grey,
-                        ),
-                        const SizedBox(height: 16),
-                        Text(
-                          'No projections generated yet.',
-                          style: TextStyle(
-                            fontSize: 18,
-                            color: Colors.grey[700],
-                          ),
-                        ),
-                        const SizedBox(height: 8),
-                        Text(
-                          'Please run a simulation to see the data.',
-                          style: TextStyle(
-                            fontSize: 14,
-                            color: Colors.grey[500],
-                          ),
-                        ),
-                      ],
-                    ),
-                  );
-                }
-
-          // Find the record for the current month (or closest available)
-          final now = DateTime.now();
-          final currentRecord =
-              _selectedRecord ??
-              records.firstWhere(
-                (r) => r.date.year == now.year && r.date.month == now.month,
-                orElse: () => records.last,
-              );
-
-          final currencyFormat = NumberFormat.currency(
-            locale: 'pt_BR',
-            symbol: 'R\$',
-          );
-
-          final monthName = DateFormat('MMMM yyyy').format(currentRecord.date);
-
-          // Prepare KPI data
-          final kpis = [
-            (
-              'Total MRR',
-              currencyFormat.format(currentRecord.saasMetrics.totalMrr),
-              Icons.attach_money,
-              Colors.green,
-            ),
-            (
-              'Active Users',
-              '${currentRecord.saasMetrics.activeCustomers}',
-              Icons.people,
-              Colors.blue,
-            ),
-            (
-              'Gross Profit',
-              currencyFormat.format(currentRecord.incomeStatement.grossProfit),
-              Icons.trending_up,
-              Colors.orange,
-            ),
-            (
-              'Cash Balance',
-              currencyFormat.format(currentRecord.cashFlow.endingBalance),
-              Icons.account_balance_wallet,
-              Colors.purple,
-            ),
-          ];
-
-          return CustomScrollView(
-            key: const ValueKey('content'),
-            slivers: [
-              SliverPadding(
-                padding: const EdgeInsets.all(16.0),
-                sliver: SliverList(
-                  delegate: SliverChildListDelegate([
-                    Text(
-                      'Key Metrics ($monthName)',
-                      style: TextStyle(
-                        fontSize: 20,
-                        fontWeight: FontWeight.w600,
-                      ),
-                    ),
-                    const SizedBox(height: 16),
-                  ]),
-                ),
-              ),
-              SliverPadding(
-                padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                sliver: SliverGrid(
-                  gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
-                    maxCrossAxisExtent: 400,
-                    mainAxisExtent:
-                        220, // Increased height for KPI cards to prevent overflow
-                    crossAxisSpacing: 16,
-                    mainAxisSpacing: 16,
-                  ),
-                  delegate: SliverChildBuilderDelegate((context, index) {
-                    final kpi = kpis[index];
-                    return KPICard(
-                      title: kpi.$1,
-                      value: kpi.$2,
-                      icon: kpi.$3,
-                      color: kpi.$4,
-                    );
-                  }, childCount: kpis.length),
-                ),
-              ),
-              SliverPadding(
-                padding: const EdgeInsets.all(16.0),
-                sliver: SliverList(
-                  delegate: SliverChildListDelegate([
-                    const SizedBox(height: 32),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Text(
-                          'Revenue Trend',
-                          style: TextStyle(
-                            fontSize: 20,
-                            fontWeight: FontWeight.w600,
-                          ),
-                        ),
-                        SegmentedButton<ChartTimeframe>(
-                          segments: const [
-                            ButtonSegment(
-                              value: ChartTimeframe.month,
-                              label: Text('Month'),
-                              icon: Icon(Icons.calendar_view_month),
-                            ),
-                            ButtonSegment(
-                              value: ChartTimeframe.year,
-                              label: Text('Year'),
-                              icon: Icon(Icons.calendar_today),
-                            ),
-                          ],
-                          selected: {_selectedTimeframe},
-                          onSelectionChanged:
-                              (Set<ChartTimeframe> newSelection) {
-                                setState(() {
-                                  _selectedTimeframe = newSelection.first;
-                                });
-                              },
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 16),
-                    Card(
-                      elevation: 0,
-                      color: Theme.of(context).colorScheme.surface,
-                      shape: RoundedRectangleBorder(
-                        side: BorderSide(
-                          color: Theme.of(context).colorScheme.outlineVariant,
-                        ),
-                        borderRadius: BorderRadius.circular(16),
-                      ),
-                      child: Padding(
-                        padding: const EdgeInsets.all(24.0),
-                        child: SizedBox(
-                          height: 300,
-                          child: RevenueChart(
-                            records: records,
-                            timeframe: _selectedTimeframe,
-                            focusedRecord: currentRecord,
-                            onRecordSelected: (record) {
-                              setState(() {
-                                _selectedRecord = record;
-                              });
-                            },
-                          ),
-                        ),
-                      ),
-                    ),
-                    const SizedBox(height: 80),
-                  ]),
-                ),
-              ),
-            ],
-          );
-        },
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (err, stack) => Center(child: Text('Error: $err')),
-      ),
+        actions: [
+          IconButton(
+            onPressed: () => _showSimulationDialog(context),
+            icon: const Icon(Icons.add_chart),
+            tooltip: 'Run Simulation',
           ),
         ],
       ),
-);
+      body: Stack(
+        children: [
+          Row(
+            children: [
+              if (isDesktop)
+                NavigationRail(
+                  extended: Breakpoints.large.isActive(context),
+                  destinations: const [
+                    NavigationRailDestination(
+                      icon: Icon(Icons.dashboard_outlined),
+                      selectedIcon: Icon(Icons.dashboard),
+                      label: Text('Dashboard'),
+                    ),
+                    NavigationRailDestination(
+                      icon: Opacity(opacity: 0.0, child: Icon(Icons.circle)),
+                      label: Text(''),
+                      disabled: true,
+                    ),
+                  ],
+                  selectedIndex: 0,
+                  trailing: Expanded(
+                    child: Padding(
+                      padding: const EdgeInsets.all(16.0),
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.end,
+                        children: [
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.end,
+                            children: [
+                              if (Breakpoints.large.isActive(context))
+                                TextButton.icon(
+                                  onPressed: () => _signOut(context, ref),
+                                  icon: const Icon(
+                                    Icons.logout,
+                                    color: Colors.red,
+                                  ),
+                                  label: const Text(
+                                    'Sign Out',
+                                    style: TextStyle(color: Colors.red),
+                                  ),
+                                )
+                              else
+                                IconButton(
+                                  onPressed: () => _signOut(context, ref),
+                                  icon: const Icon(Icons.logout),
+                                  tooltip: 'Sign Out',
+                                  color: Colors.red,
+                                ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              Expanded(
+                child: projectionsAsync.when(
+                  data: (records) {
+                    if (records.isEmpty) {
+                      return Center(
+                        key: const ValueKey('empty_state'),
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            const Icon(
+                              Icons.analytics_outlined,
+                              size: 64,
+                              color: Colors.grey,
+                            ),
+                            const SizedBox(height: 16),
+                            Text(
+                              'No projections generated yet.',
+                              style: TextStyle(
+                                fontSize: 18,
+                                color: Colors.grey[700],
+                              ),
+                            ),
+                            const SizedBox(height: 8),
+                            Text(
+                              'Please run a simulation to see the data.',
+                              style: TextStyle(
+                                fontSize: 14,
+                                color: Colors.grey[500],
+                              ),
+                            ),
+                            const SizedBox(height: 24),
+                            FilledButton.icon(
+                              onPressed: () => _showSimulationDialog(context),
+                              icon: const Icon(Icons.play_arrow),
+                              label: const Text('Run Simulation'),
+                            ),
+                          ],
+                        ),
+                      );
+                    }
+
+                    final now = DateTime.now();
+                    final currentRecord =
+                        _selectedRecord ??
+                        records.firstWhere(
+                          (r) =>
+                              r.date.year == now.year &&
+                              r.date.month == now.month,
+                          orElse: () => records.last,
+                        );
+
+                    final currencyFormat = NumberFormat.currency(
+                      locale: 'pt_BR',
+                      symbol: 'R\$',
+                    );
+
+                    final monthName = DateFormat(
+                      'MMMM yyyy',
+                    ).format(currentRecord.date);
+
+                    final kpis = [
+                      (
+                        'Total MRR',
+                        currencyFormat.format(
+                          currentRecord.saasMetrics.totalMrr,
+                        ),
+                        Icons.attach_money,
+                        Colors.green,
+                      ),
+                      (
+                        'Active Users',
+                        '${currentRecord.saasMetrics.activeCustomers}',
+                        Icons.people,
+                        Colors.blue,
+                      ),
+                      (
+                        'Gross Profit',
+                        currencyFormat.format(
+                          currentRecord.incomeStatement.grossProfit,
+                        ),
+                        Icons.trending_up,
+                        Colors.orange,
+                      ),
+                      (
+                        'Cash Balance',
+                        currencyFormat.format(
+                          currentRecord.cashFlow.endingBalance,
+                        ),
+                        Icons.account_balance_wallet,
+                        Colors.purple,
+                      ),
+                    ];
+
+                    return CustomScrollView(
+                      key: const ValueKey('content'),
+                      slivers: [
+                        SliverPadding(
+                          padding: const EdgeInsets.all(16.0),
+                          sliver: SliverList(
+                            delegate: SliverChildListDelegate([
+                              Text(
+                                'Key Metrics ($monthName)',
+                                style: const TextStyle(
+                                  fontSize: 20,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                              const SizedBox(height: 16),
+                            ]),
+                          ),
+                        ),
+                        SliverPadding(
+                          padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                          sliver: SliverGrid(
+                            gridDelegate:
+                                const SliverGridDelegateWithMaxCrossAxisExtent(
+                                  maxCrossAxisExtent: 400,
+                                  mainAxisExtent: 220,
+                                  crossAxisSpacing: 16,
+                                  mainAxisSpacing: 16,
+                                ),
+                            delegate: SliverChildBuilderDelegate((
+                              context,
+                              index,
+                            ) {
+                              final kpi = kpis[index];
+                              return KPICard(
+                                title: kpi.$1,
+                                value: kpi.$2,
+                                icon: kpi.$3,
+                                color: kpi.$4,
+                              );
+                            }, childCount: kpis.length),
+                          ),
+                        ),
+                        SliverPadding(
+                          padding: const EdgeInsets.all(16.0),
+                          sliver: SliverList(
+                            delegate: SliverChildListDelegate([
+                              const SizedBox(height: 32),
+                              Row(
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
+                                children: [
+                                  const Text(
+                                    'Revenue Trend',
+                                    style: TextStyle(
+                                      fontSize: 20,
+                                      fontWeight: FontWeight.w600,
+                                    ),
+                                  ),
+                                  SegmentedButton<ChartTimeframe>(
+                                    segments: const [
+                                      ButtonSegment(
+                                        value: ChartTimeframe.month,
+                                        label: Text('Month'),
+                                        icon: Icon(Icons.calendar_view_month),
+                                      ),
+                                      ButtonSegment(
+                                        value: ChartTimeframe.year,
+                                        label: Text('Year'),
+                                        icon: Icon(Icons.calendar_today),
+                                      ),
+                                    ],
+                                    selected: {_selectedTimeframe},
+                                    onSelectionChanged: (newSelection) {
+                                      setState(() {
+                                        _selectedTimeframe = newSelection.first;
+                                      });
+                                    },
+                                  ),
+                                ],
+                              ),
+                              const SizedBox(height: 16),
+                              Card(
+                                elevation: 0,
+                                color: Theme.of(context).colorScheme.surface,
+                                shape: RoundedRectangleBorder(
+                                  side: BorderSide(
+                                    color: Theme.of(
+                                      context,
+                                    ).colorScheme.outlineVariant,
+                                  ),
+                                  borderRadius: BorderRadius.circular(16),
+                                ),
+                                child: Padding(
+                                  padding: const EdgeInsets.all(24.0),
+                                  child: SizedBox(
+                                    height: 300,
+                                    child: RevenueChart(
+                                      records: records,
+                                      timeframe: _selectedTimeframe,
+                                      focusedRecord: currentRecord,
+                                      onRecordSelected: (record) {
+                                        setState(() {
+                                          _selectedRecord = record;
+                                        });
+                                      },
+                                    ),
+                                  ),
+                                ),
+                              ),
+                              const SizedBox(height: 80),
+                            ]),
+                          ),
+                        ),
+                      ],
+                    );
+                  },
+                  loading: () =>
+                      const Center(child: CircularProgressIndicator()),
+                  error: (err, stack) => Center(child: Text('Error: $err')),
+                ),
+              ),
+            ],
+          ),
+          if (projectionsAsync.isLoading &&
+              projectionsAsync.hasValue &&
+              projectionsAsync.value!.isNotEmpty)
+            Container(
+              color: Colors.black.withOpacity(0.3),
+              child: Center(
+                child: Card(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 32,
+                      vertical: 24,
+                    ),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        const CircularProgressIndicator(),
+                        const SizedBox(height: 16),
+                        Text(
+                          'Generating projections...',
+                          style: Theme.of(context).textTheme.titleMedium,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  void _showSimulationDialog(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (context) => const SimulationDialog(),
+    );
   }
 
   Future<void> _signOut(BuildContext context, WidgetRef ref) async {

--- a/lib/features/financial_modeling/presentation/widgets/simulation_dialog.dart
+++ b/lib/features/financial_modeling/presentation/widgets/simulation_dialog.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uuid/uuid.dart';
+import '../providers/financial_projections_provider.dart';
+import '../../domain/entities/financial_scenario.dart';
+
+class SimulationDialog extends ConsumerStatefulWidget {
+  const SimulationDialog({super.key});
+
+  @override
+  ConsumerState<SimulationDialog> createState() => _SimulationDialogState();
+}
+
+class _SimulationDialogState extends ConsumerState<SimulationDialog> {
+  final _formKey = GlobalKey<FormState>();
+  final _startingCustomersController = TextEditingController(text: '100');
+  final _arpaController = TextEditingController(text: '50.0');
+  final _churnRateController = TextEditingController(text: '0.05');
+  final _durationController = TextEditingController(text: '12');
+
+  @override
+  void dispose() {
+    _startingCustomersController.dispose();
+    _arpaController.dispose();
+    _churnRateController.dispose();
+    _durationController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('New Financial Simulation'),
+      content: SingleChildScrollView(
+        child: Form(
+          key: _formKey,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextFormField(
+                controller: _startingCustomersController,
+                decoration: const InputDecoration(
+                  labelText: 'Starting Customers',
+                  helperText: 'Initial active customer base',
+                ),
+                keyboardType: TextInputType.number,
+                validator: (value) =>
+                    value == null || int.tryParse(value) == null
+                    ? 'Enter a valid number'
+                    : null,
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _arpaController,
+                decoration: const InputDecoration(
+                  labelText: 'ARPA (Monthly)',
+                  prefixText: 'R\$ ',
+                ),
+                keyboardType: TextInputType.number,
+                validator: (value) =>
+                    value == null || double.tryParse(value) == null
+                    ? 'Enter a valid number'
+                    : null,
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _churnRateController,
+                decoration: const InputDecoration(
+                  labelText: 'Monthly Churn Rate',
+                  suffixText: '%',
+                  helperText: 'Example: 0.05 for 5%',
+                ),
+                keyboardType: TextInputType.number,
+                validator: (value) =>
+                    value == null || double.tryParse(value) == null
+                    ? 'Enter a valid number'
+                    : null,
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _durationController,
+                decoration: const InputDecoration(
+                  labelText: 'Simulation Duration (Months)',
+                ),
+                keyboardType: TextInputType.number,
+                validator: (value) =>
+                    value == null || int.tryParse(value) == null
+                    ? 'Enter a valid number'
+                    : null,
+              ),
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: _runSimulation,
+          child: const Text('Run Simulation'),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _runSimulation() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    final scenario = FinancialScenario(
+      id: const Uuid().v4(),
+      name: 'Custom Simulation',
+      startDate: DateTime.now(),
+      durationMonths: int.parse(_durationController.text),
+      parameters: {
+        'starting_customers': int.parse(_startingCustomersController.text),
+        'arpa': double.parse(_arpaController.text),
+        'churn_rate': double.parse(_churnRateController.text),
+        'new_customers_monthly': 10, // Default value for now
+        'marketing_spend': 1000.0,
+        'fixed_opex': 5000.0,
+        'tax_rate': 0.15,
+      },
+    );
+
+    Navigator.of(context).pop();
+    await ref.read(financialProjectionsProvider.notifier).generate(scenario);
+  }
+}

--- a/lib/features/onboarding/data/repositories/onboarding_repository_impl.dart
+++ b/lib/features/onboarding/data/repositories/onboarding_repository_impl.dart
@@ -1,0 +1,18 @@
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:saas_metrics/features/onboarding/domain/repositories/onboarding_repository.dart';
+
+class OnboardingRepositoryImpl implements OnboardingRepository {
+  static const String _onboardingKey = 'has_seen_onboarding';
+
+  @override
+  Future<bool> hasSeenOnboarding() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_onboardingKey) ?? false;
+  }
+
+  @override
+  Future<void> markOnboardingAsSeen() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_onboardingKey, true);
+  }
+}

--- a/lib/features/onboarding/domain/repositories/onboarding_repository.dart
+++ b/lib/features/onboarding/domain/repositories/onboarding_repository.dart
@@ -1,0 +1,7 @@
+abstract class OnboardingRepository {
+  /// Returns true if the user has already seen the onboarding flow.
+  Future<bool> hasSeenOnboarding();
+
+  /// Marks the onboarding flow as seen by the user.
+  Future<void> markOnboardingAsSeen();
+}

--- a/lib/features/onboarding/presentation/pages/onboarding_page.dart
+++ b/lib/features/onboarding/presentation/pages/onboarding_page.dart
@@ -1,15 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:saas_metrics/core/router/app_router.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:saas_metrics/features/onboarding/presentation/providers/onboarding_provider.dart';
 
-class OnboardingPage extends StatefulWidget {
+class OnboardingPage extends ConsumerStatefulWidget {
   const OnboardingPage({super.key});
 
   @override
-  State<OnboardingPage> createState() => _OnboardingPageState();
+  ConsumerState<OnboardingPage> createState() => _OnboardingPageState();
 }
 
-class _OnboardingPageState extends State<OnboardingPage> {
+class _OnboardingPageState extends ConsumerState<OnboardingPage> {
   final PageController _pageController = PageController();
   int _currentPage = 0;
 
@@ -72,7 +74,10 @@ class _OnboardingPageState extends State<OnboardingPage> {
         children: [
           if (!isLastPage)
             TextButton(
-              onPressed: () => context.go(AppRoutes.login),
+              onPressed: () {
+                ref.read(onboardingProvider.notifier).completeOnboarding();
+                context.go(AppRoutes.login);
+              },
               child: Text(
                 'Skip',
                 style: theme.textTheme.labelLarge?.copyWith(
@@ -86,6 +91,7 @@ class _OnboardingPageState extends State<OnboardingPage> {
           FilledButton(
             onPressed: () {
               if (isLastPage) {
+                ref.read(onboardingProvider.notifier).completeOnboarding();
                 context.go(AppRoutes.login);
               } else {
                 _pageController.nextPage(

--- a/lib/features/onboarding/presentation/providers/onboarding_provider.dart
+++ b/lib/features/onboarding/presentation/providers/onboarding_provider.dart
@@ -1,0 +1,26 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:saas_metrics/features/onboarding/data/repositories/onboarding_repository_impl.dart';
+import 'package:saas_metrics/features/onboarding/domain/repositories/onboarding_repository.dart';
+
+part 'onboarding_provider.g.dart';
+
+@riverpod
+OnboardingRepository onboardingRepository(Ref ref) => OnboardingRepositoryImpl();
+
+@riverpod
+class Onboarding extends _$Onboarding {
+  @override
+  FutureOr<bool> build() async {
+    final repository = ref.read(onboardingRepositoryProvider);
+    return await repository.hasSeenOnboarding();
+  }
+
+  Future<void> completeOnboarding() async {
+    state = const AsyncValue.loading();
+    state = await AsyncValue.guard(() async {
+      final repository = ref.read(onboardingRepositoryProvider);
+      await repository.markOnboardingAsSeen();
+      return true;
+    });
+  }
+}

--- a/lib/features/onboarding/presentation/providers/onboarding_provider.g.dart
+++ b/lib/features/onboarding/presentation/providers/onboarding_provider.g.dart
@@ -1,0 +1,102 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'onboarding_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(onboardingRepository)
+final onboardingRepositoryProvider = OnboardingRepositoryProvider._();
+
+final class OnboardingRepositoryProvider
+    extends
+        $FunctionalProvider<
+          OnboardingRepository,
+          OnboardingRepository,
+          OnboardingRepository
+        >
+    with $Provider<OnboardingRepository> {
+  OnboardingRepositoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'onboardingRepositoryProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$onboardingRepositoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<OnboardingRepository> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  OnboardingRepository create(Ref ref) {
+    return onboardingRepository(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(OnboardingRepository value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<OnboardingRepository>(value),
+    );
+  }
+}
+
+String _$onboardingRepositoryHash() =>
+    r'bdfe79ffa614fdfe90b7d946c08dade9d7c8195d';
+
+@ProviderFor(Onboarding)
+final onboardingProvider = OnboardingProvider._();
+
+final class OnboardingProvider
+    extends $AsyncNotifierProvider<Onboarding, bool> {
+  OnboardingProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'onboardingProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$onboardingHash();
+
+  @$internal
+  @override
+  Onboarding create() => Onboarding();
+}
+
+String _$onboardingHash() => r'bf53589d0627aeafb7d513a8fec9b896b514ae36';
+
+abstract class _$Onboarding extends $AsyncNotifier<bool> {
+  FutureOr<bool> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<AsyncValue<bool>, bool>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<bool>, bool>,
+              AsyncValue<bool>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 0.1.0
 
 environment:
-  sdk: ^3.10.4
+  sdk: ^3.9.0
 
 dependencies:
   flutter:
@@ -18,13 +18,14 @@ dependencies:
   shared_preferences: ^2.5.4
   flutter_adaptive_scaffold: ^0.3.3+1
   go_router: ^17.1.0
+  uuid: ^4.0.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
   riverpod_generator: ^4.0.0+1
-  build_runner: ^2.10.4
+  build_runner: ^2.4.9
 
 flutter:
   uses-material-design: true

--- a/test/features/financial_modeling/presentation/pages/dashboard_page_test.dart
+++ b/test/features/financial_modeling/presentation/pages/dashboard_page_test.dart
@@ -33,10 +33,11 @@ void main() {
     // We expect the 'No projections generated yet.' text to be visible in the body
     expect(find.text('No projections generated yet.'), findsOneWidget);
 
+    expect(find.byIcon(Icons.play_arrow), findsOneWidget);
     expect(
-      find.byIcon(Icons.play_arrow),
-      findsNothing,
-    ); // Play button removed as requested
+      find.text('Run Simulation'),
+      findsWidgets,
+    ); // BothAppBar and EmptyState
   });
 
   testWidgets('DashboardPage renders empty state message', (

--- a/test/features/onboarding/onboarding_test.dart
+++ b/test/features/onboarding/onboarding_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:saas_metrics/features/onboarding/data/repositories/onboarding_repository_impl.dart';
+import 'package:saas_metrics/features/onboarding/presentation/providers/onboarding_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group('OnboardingRepositoryImpl', () {
+    late OnboardingRepositoryImpl repository;
+
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+      repository = OnboardingRepositoryImpl();
+    });
+
+    test('hasSeenOnboarding returns false by default', () async {
+      final result = await repository.hasSeenOnboarding();
+      expect(result, isFalse);
+    });
+
+    test('markOnboardingAsSeen updates value to true', () async {
+      await repository.markOnboardingAsSeen();
+      final result = await repository.hasSeenOnboarding();
+      expect(result, isTrue);
+    });
+  });
+
+  group('OnboardingNotifier', () {
+    late ProviderContainer container;
+
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+      container = ProviderContainer();
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    test('initial state is false', () async {
+      final state = await container.read(onboardingProvider.future);
+      expect(state, isFalse);
+    });
+
+    test('completeOnboarding updates state to true', () async {
+      await container.read(onboardingProvider.notifier).completeOnboarding();
+      final state = await container.read(onboardingProvider.future);
+      expect(state, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
Closes #6.

## Description
This PR implements logic to ensure the onboarding flow is only shown on the very first app launch and adds a dashboard simulation trigger with a loading overlay.

## Changes

### First-Run Onboarding
- **Domain**: Added `OnboardingRepository` interface.
- **Data**: Added `OnboardingRepositoryImpl` with `SharedPreferences` integration.
- **Presentation**: Added `OnboardingNotifier` (Riverpod) and updated `OnboardingPage` to trigger completion.
- **Core**: Integrated onboarding state into `AppRouter` for smart redirection.

### Dashboard Simulation
- **UI**: Added a "Run Simulation" button to the Dashboard's empty state.
- **UI**: Added an `add_chart` icon in the AppBar to trigger simulations at any time.
- **Simulation**: Implemented `SimulationDialog` to collect parameters (Starting Customers, ARPA, Churn, etc.).
- **Feedback**: Added a loading overlay with the message **"Generating projections..."** while the simulation is running.

## Engineering Fixes
- **Environment**: Downgraded `build_runner` and lowered SDK requirement to `^3.9.0` for environment compatibility.
- **Dependencies**: Added `uuid` for scenario ID generation.

## Verification
- **Automated Tests**: Total 18 tests passing (including 4 new onboarding tests and updated dashboard tests).
- **Manual Flow**: Verified onboarding persistence and the new simulation trigger flow with loading feedback.
