### PR TITLE
feat: implement scenario persistence and enhanced inputs

### DIFF
--- a/lib/core/router/app_router.g.dart
+++ b/lib/core/router/app_router.g.dart
@@ -52,4 +52,4 @@ final class AppRouterProvider
   }
 }
 
-String _$appRouterHash() => r'a6207a9db387c03d65b3e281088f1475bc1f04f8';
+String _$appRouterHash() => r'b3c746ebb3c9fb88237aead472f66493b79da7b5';

--- a/lib/features/financial_modeling/data/repositories/financial_repository_impl.dart
+++ b/lib/features/financial_modeling/data/repositories/financial_repository_impl.dart
@@ -1,0 +1,65 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../../domain/entities/financial_scenario.dart';
+import '../../domain/repositories/financial_repository.dart';
+
+class FinancialRepositoryImpl implements FinancialRepository {
+  static const String _storageKey = 'financial_scenarios';
+
+  @override
+  Future<List<FinancialScenario>> getAllScenarios() async {
+    final prefs = await SharedPreferences.getInstance();
+    final jsonString = prefs.getString(_storageKey);
+
+    if (jsonString == null) {
+      return [];
+    }
+
+    try {
+      final List<dynamic> jsonList = jsonDecode(jsonString);
+      return jsonList
+          .map((e) => FinancialScenario.fromMap(e as Map<String, dynamic>))
+          .toList();
+    } catch (e) {
+      // In case of corruption, return empty or handle error
+      return [];
+    }
+  }
+
+  @override
+  Future<FinancialScenario?> getScenario(String id) async {
+    final scenarios = await getAllScenarios();
+    try {
+      return scenarios.firstWhere((element) => element.id == id);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  @override
+  Future<void> saveScenario(FinancialScenario scenario) async {
+    final prefs = await SharedPreferences.getInstance();
+    final scenarios = await getAllScenarios();
+    
+    final index = scenarios.indexWhere((s) => s.id == scenario.id);
+    if (index >= 0) {
+      scenarios[index] = scenario;
+    } else {
+      scenarios.add(scenario);
+    }
+
+    final jsonList = scenarios.map((s) => s.toMap()).toList();
+    await prefs.setString(_storageKey, jsonEncode(jsonList));
+  }
+
+  @override
+  Future<void> deleteScenario(String id) async {
+    final prefs = await SharedPreferences.getInstance();
+    final scenarios = await getAllScenarios();
+    
+    scenarios.removeWhere((s) => s.id == id);
+    
+    final jsonList = scenarios.map((s) => s.toMap()).toList();
+    await prefs.setString(_storageKey, jsonEncode(jsonList));
+  }
+}

--- a/lib/features/financial_modeling/domain/entities/financial_scenario.dart
+++ b/lib/features/financial_modeling/domain/entities/financial_scenario.dart
@@ -18,4 +18,40 @@ class FinancialScenario extends Equatable {
 
   @override
   List<Object> get props => [id, name, startDate, durationMonths, parameters];
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'name': name,
+      'startDate': startDate.toIso8601String(),
+      'durationMonths': durationMonths,
+      'parameters': parameters,
+    };
+  }
+
+  factory FinancialScenario.fromMap(Map<String, dynamic> map) {
+    return FinancialScenario(
+      id: map['id'] ?? '',
+      name: map['name'] ?? '',
+      startDate: DateTime.tryParse(map['startDate'] ?? '') ?? DateTime.now(),
+      durationMonths: map['durationMonths']?.toInt() ?? 12,
+      parameters: Map<String, dynamic>.from(map['parameters'] ?? {}),
+    );
+  }
+
+  FinancialScenario copyWith({
+    String? id,
+    String? name,
+    DateTime? startDate,
+    int? durationMonths,
+    Map<String, dynamic>? parameters,
+  }) {
+    return FinancialScenario(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      startDate: startDate ?? this.startDate,
+      durationMonths: durationMonths ?? this.durationMonths,
+      parameters: parameters ?? this.parameters,
+    );
+  }
 }

--- a/lib/features/financial_modeling/domain/repositories/financial_repository.dart
+++ b/lib/features/financial_modeling/domain/repositories/financial_repository.dart
@@ -2,9 +2,15 @@ import '../entities/financial_scenario.dart';
 
 /// Contract for persisting and retrieving financial scenarios.
 abstract class FinancialRepository {
+  /// Retrieves all saved scenarios.
+  Future<List<FinancialScenario>> getAllScenarios();
+
   /// Retrieves a saved scenario by its ID.
-  Future<FinancialScenario> getScenario(String id);
+  Future<FinancialScenario?> getScenario(String id);
 
   /// Saves a financial scenario.
   Future<void> saveScenario(FinancialScenario scenario);
+
+  /// Deletes a financial scenario.
+  Future<void> deleteScenario(String id);
 }

--- a/lib/features/financial_modeling/presentation/pages/dashboard_page.dart
+++ b/lib/features/financial_modeling/presentation/pages/dashboard_page.dart
@@ -12,6 +12,8 @@ import '../widgets/kpi_card.dart';
 import '../widgets/revenue_chart.dart';
 import '../widgets/simulation_dialog.dart';
 
+import '../widgets/saved_scenarios_dialog.dart';
+
 class DashboardPage extends ConsumerStatefulWidget {
   const DashboardPage({super.key});
 
@@ -29,6 +31,31 @@ class _DashboardPageState extends ConsumerState<DashboardPage> {
     final isDesktop = Breakpoints.mediumAndUp.isActive(context);
 
     return Scaffold(
+      floatingActionButton: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          FloatingActionButton.extended(
+            heroTag: 'saved_scenarios',
+            onPressed: () {
+              showDialog(
+                context: context,
+                builder: (context) => const SavedScenariosDialog(),
+              );
+            },
+            icon: const Icon(Icons.folder_open),
+            label: const Text('Saved'),
+            backgroundColor: Theme.of(context).colorScheme.surfaceContainerHigh,
+            foregroundColor: Theme.of(context).colorScheme.primary,
+          ),
+          const SizedBox(width: 16),
+          FloatingActionButton.extended(
+            heroTag: 'new_simulation',
+            onPressed: () => _showSimulationDialog(context),
+            icon: const Icon(Icons.play_arrow),
+            label: const Text('New Simulation'),
+          ),
+        ],
+      ),
       appBar: AppBar(
         title: const Text(
           'SaaS Financial Dashboard',

--- a/lib/features/financial_modeling/presentation/providers/financial_repository_provider.dart
+++ b/lib/features/financial_modeling/presentation/providers/financial_repository_provider.dart
@@ -1,0 +1,36 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import '../../data/repositories/financial_repository_impl.dart';
+import '../../domain/entities/financial_scenario.dart';
+import '../../domain/repositories/financial_repository.dart';
+
+part 'financial_repository_provider.g.dart';
+
+@riverpod
+FinancialRepository financialRepository(Ref ref) => FinancialRepositoryImpl();
+
+@riverpod
+class SavedScenarios extends _$SavedScenarios {
+  @override
+  FutureOr<List<FinancialScenario>> build() async {
+    final repository = ref.watch(financialRepositoryProvider);
+    return repository.getAllScenarios();
+  }
+
+  Future<void> saveScenario(FinancialScenario scenario) async {
+    state = const AsyncValue.loading();
+    state = await AsyncValue.guard(() async {
+      final repository = ref.read(financialRepositoryProvider);
+      await repository.saveScenario(scenario);
+      return repository.getAllScenarios();
+    });
+  }
+
+  Future<void> deleteScenario(String id) async {
+    state = const AsyncValue.loading();
+    state = await AsyncValue.guard(() async {
+      final repository = ref.read(financialRepositoryProvider);
+      await repository.deleteScenario(id);
+      return repository.getAllScenarios();
+    });
+  }
+}

--- a/lib/features/financial_modeling/presentation/providers/financial_repository_provider.g.dart
+++ b/lib/features/financial_modeling/presentation/providers/financial_repository_provider.g.dart
@@ -1,0 +1,111 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'financial_repository_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(financialRepository)
+final financialRepositoryProvider = FinancialRepositoryProvider._();
+
+final class FinancialRepositoryProvider
+    extends
+        $FunctionalProvider<
+          FinancialRepository,
+          FinancialRepository,
+          FinancialRepository
+        >
+    with $Provider<FinancialRepository> {
+  FinancialRepositoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'financialRepositoryProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$financialRepositoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<FinancialRepository> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  FinancialRepository create(Ref ref) {
+    return financialRepository(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(FinancialRepository value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<FinancialRepository>(value),
+    );
+  }
+}
+
+String _$financialRepositoryHash() =>
+    r'4a205d3eb1f9d7b7b3503ae29c83e0a27862901a';
+
+@ProviderFor(SavedScenarios)
+final savedScenariosProvider = SavedScenariosProvider._();
+
+final class SavedScenariosProvider
+    extends $AsyncNotifierProvider<SavedScenarios, List<FinancialScenario>> {
+  SavedScenariosProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'savedScenariosProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$savedScenariosHash();
+
+  @$internal
+  @override
+  SavedScenarios create() => SavedScenarios();
+}
+
+String _$savedScenariosHash() => r'a39f6d32715678a76123369e81214449dbb569cc';
+
+abstract class _$SavedScenarios
+    extends $AsyncNotifier<List<FinancialScenario>> {
+  FutureOr<List<FinancialScenario>> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref =
+        this.ref
+            as $Ref<
+              AsyncValue<List<FinancialScenario>>,
+              List<FinancialScenario>
+            >;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<
+                AsyncValue<List<FinancialScenario>>,
+                List<FinancialScenario>
+              >,
+              AsyncValue<List<FinancialScenario>>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/lib/features/financial_modeling/presentation/widgets/saved_scenarios_dialog.dart
+++ b/lib/features/financial_modeling/presentation/widgets/saved_scenarios_dialog.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../domain/entities/financial_scenario.dart';
+import '../providers/financial_projections_provider.dart';
+import '../providers/financial_repository_provider.dart';
+import 'package:intl/intl.dart';
+
+class SavedScenariosDialog extends ConsumerWidget {
+  const SavedScenariosDialog({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final scenariosAsync = ref.watch(savedScenariosProvider);
+
+    return AlertDialog(
+      title: const Text('Saved Simulations'),
+      content: SizedBox(
+        width: double.maxFinite,
+        height: 400,
+        child: scenariosAsync.when(
+          data: (scenarios) {
+            if (scenarios.isEmpty) {
+              return const Center(child: Text('No saved simulations found.'));
+            }
+            return ListView.separated(
+              itemCount: scenarios.length,
+              separatorBuilder: (_, __) => const Divider(),
+              itemBuilder: (context, index) {
+                final scenario = scenarios[index];
+                return ListTile(
+                  title: Text(scenario.name),
+                  subtitle: Text(
+                    '${DateFormat.yMMMd().format(scenario.startDate)} • ${scenario.durationMonths} months',
+                  ),
+                  trailing: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      IconButton(
+                        icon: const Icon(Icons.play_arrow),
+                        color: Colors.green,
+                        onPressed: () {
+                          _loadScenario(context, ref, scenario);
+                        },
+                      ),
+                      IconButton(
+                        icon: const Icon(Icons.delete),
+                        color: Colors.red,
+                        onPressed: () {
+                          ref
+                              .read(savedScenariosProvider.notifier)
+                              .deleteScenario(scenario.id);
+                        },
+                      ),
+                    ],
+                  ),
+                  onTap: () => _loadScenario(context, ref, scenario),
+                );
+              },
+            );
+          },
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (err, stack) => Center(child: Text('Error: $err')),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Close'),
+        ),
+      ],
+    );
+  }
+
+  void _loadScenario(
+    BuildContext context,
+    WidgetRef ref,
+    FinancialScenario scenario,
+  ) {
+    Navigator.of(context).pop();
+    ref.read(financialProjectionsProvider.notifier).generate(scenario);
+  }
+}

--- a/lib/features/financial_modeling/presentation/widgets/simulation_dialog.dart
+++ b/lib/features/financial_modeling/presentation/widgets/simulation_dialog.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:uuid/uuid.dart';
 import '../providers/financial_projections_provider.dart';
 import '../../domain/entities/financial_scenario.dart';
+import '../providers/financial_repository_provider.dart';
 
 class SimulationDialog extends ConsumerStatefulWidget {
   const SimulationDialog({super.key});
@@ -13,16 +14,26 @@ class SimulationDialog extends ConsumerStatefulWidget {
 
 class _SimulationDialogState extends ConsumerState<SimulationDialog> {
   final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController(text: 'My Simulation');
   final _startingCustomersController = TextEditingController(text: '100');
+  final _newCustomersController = TextEditingController(text: '10');
   final _arpaController = TextEditingController(text: '50.0');
   final _churnRateController = TextEditingController(text: '0.05');
+  final _marketingSpendController = TextEditingController(text: '1000.0');
+  final _fixedOpexController = TextEditingController(text: '5000.0');
+  final _taxRateController = TextEditingController(text: '0.15');
   final _durationController = TextEditingController(text: '12');
 
   @override
   void dispose() {
+    _nameController.dispose();
     _startingCustomersController.dispose();
+    _newCustomersController.dispose();
     _arpaController.dispose();
     _churnRateController.dispose();
+    _marketingSpendController.dispose();
+    _fixedOpexController.dispose();
+    _taxRateController.dispose();
     _durationController.dispose();
     super.dispose();
   }
@@ -38,55 +49,120 @@ class _SimulationDialogState extends ConsumerState<SimulationDialog> {
             mainAxisSize: MainAxisSize.min,
             children: [
               TextFormField(
-                controller: _startingCustomersController,
+                controller: _nameController,
                 decoration: const InputDecoration(
-                  labelText: 'Starting Customers',
-                  helperText: 'Initial active customer base',
+                  labelText: 'Scenario Name',
+                  isDense: true,
+                  prefixIcon: Icon(Icons.label_outline),
                 ),
-                keyboardType: TextInputType.number,
-                validator: (value) =>
-                    value == null || int.tryParse(value) == null
-                    ? 'Enter a valid number'
-                    : null,
+                validator: (v) =>
+                    v == null || v.isEmpty ? 'Enter a name' : null,
+              ),
+              const SizedBox(height: 24),
+              _buildSectionHeader('Growth Drivers'),
+              Row(
+                children: [
+                  Expanded(
+                    child: TextFormField(
+                      controller: _startingCustomersController,
+                      decoration: const InputDecoration(
+                        labelText: 'Starting Users',
+                        isDense: true,
+                      ),
+                      keyboardType: TextInputType.number,
+                      validator: (v) => _validateNumber(v),
+                    ),
+                  ),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: TextFormField(
+                      controller: _newCustomersController,
+                      decoration: const InputDecoration(
+                        labelText: 'New / Month',
+                        isDense: true,
+                      ),
+                      keyboardType: TextInputType.number,
+                      validator: (v) => _validateNumber(v),
+                    ),
+                  ),
+                ],
               ),
               const SizedBox(height: 16),
+              Row(
+                children: [
+                  Expanded(
+                    child: TextFormField(
+                      controller: _arpaController,
+                      decoration: const InputDecoration(
+                        labelText: 'ARPA',
+                        prefixText: 'R\$ ',
+                        isDense: true,
+                      ),
+                      keyboardType: TextInputType.number,
+                      validator: (v) => _validateDouble(v),
+                    ),
+                  ),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: TextFormField(
+                      controller: _churnRateController,
+                      decoration: const InputDecoration(
+                        labelText: 'Churn Rate',
+                        suffixText: '%',
+                        helperText: '0.05 = 5%',
+                        isDense: true,
+                      ),
+                      keyboardType: TextInputType.number,
+                      validator: (v) => _validateDouble(v),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 24),
+              _buildSectionHeader('Costs & Expenses'),
               TextFormField(
-                controller: _arpaController,
+                controller: _marketingSpendController,
                 decoration: const InputDecoration(
-                  labelText: 'ARPA (Monthly)',
+                  labelText: 'Marketing Spend (Monthly)',
                   prefixText: 'R\$ ',
+                  isDense: true,
                 ),
                 keyboardType: TextInputType.number,
-                validator: (value) =>
-                    value == null || double.tryParse(value) == null
-                    ? 'Enter a valid number'
-                    : null,
+                validator: (v) => _validateDouble(v),
               ),
               const SizedBox(height: 16),
               TextFormField(
-                controller: _churnRateController,
+                controller: _fixedOpexController,
                 decoration: const InputDecoration(
-                  labelText: 'Monthly Churn Rate',
-                  suffixText: '%',
-                  helperText: 'Example: 0.05 for 5%',
+                  labelText: 'Fixed OpEx (Monthly)',
+                  prefixText: 'R\$ ',
+                  isDense: true,
                 ),
                 keyboardType: TextInputType.number,
-                validator: (value) =>
-                    value == null || double.tryParse(value) == null
-                    ? 'Enter a valid number'
-                    : null,
+                validator: (v) => _validateDouble(v),
               ),
               const SizedBox(height: 16),
+              TextFormField(
+                controller: _taxRateController,
+                decoration: const InputDecoration(
+                  labelText: 'Tax Rate',
+                  suffixText: '%',
+                  helperText: '0.15 = 15%',
+                  isDense: true,
+                ),
+                keyboardType: TextInputType.number,
+                validator: (v) => _validateDouble(v),
+              ),
+              const SizedBox(height: 24),
+              _buildSectionHeader('Scenario Settings'),
               TextFormField(
                 controller: _durationController,
                 decoration: const InputDecoration(
-                  labelText: 'Simulation Duration (Months)',
+                  labelText: 'Duration (Months)',
+                  isDense: true,
                 ),
                 keyboardType: TextInputType.number,
-                validator: (value) =>
-                    value == null || int.tryParse(value) == null
-                    ? 'Enter a valid number'
-                    : null,
+                validator: (v) => _validateNumber(v),
               ),
             ],
           ),
@@ -99,10 +175,40 @@ class _SimulationDialogState extends ConsumerState<SimulationDialog> {
         ),
         FilledButton(
           onPressed: _runSimulation,
-          child: const Text('Run Simulation'),
+          child: const Text('Run & Save'),
         ),
       ],
     );
+  }
+
+  Widget _buildSectionHeader(String title) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: Theme.of(
+              context,
+            ).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold),
+          ),
+          const Divider(),
+        ],
+      ),
+    );
+  }
+
+  String? _validateNumber(String? value) {
+    return value == null || int.tryParse(value) == null
+        ? 'Enter a valid number'
+        : null;
+  }
+
+  String? _validateDouble(String? value) {
+    return value == null || double.tryParse(value) == null
+        ? 'Enter a valid number'
+        : null;
   }
 
   Future<void> _runSimulation() async {
@@ -110,21 +216,26 @@ class _SimulationDialogState extends ConsumerState<SimulationDialog> {
 
     final scenario = FinancialScenario(
       id: const Uuid().v4(),
-      name: 'Custom Simulation',
+      name: _nameController.text,
       startDate: DateTime.now(),
       durationMonths: int.parse(_durationController.text),
       parameters: {
         'starting_customers': int.parse(_startingCustomersController.text),
+        'new_customers_monthly': int.parse(_newCustomersController.text),
         'arpa': double.parse(_arpaController.text),
         'churn_rate': double.parse(_churnRateController.text),
-        'new_customers_monthly': 10, // Default value for now
-        'marketing_spend': 1000.0,
-        'fixed_opex': 5000.0,
-        'tax_rate': 0.15,
+        'marketing_spend': double.parse(_marketingSpendController.text),
+        'fixed_opex': double.parse(_fixedOpexController.text),
+        'tax_rate': double.parse(_taxRateController.text),
       },
     );
 
     Navigator.of(context).pop();
+    
+    // Save scenario
+    await ref.read(savedScenariosProvider.notifier).saveScenario(scenario);
+
+    // Run simulation
     await ref.read(financialProjectionsProvider.notifier).generate(scenario);
   }
 }

--- a/test/features/financial_modeling/data/repositories/financial_repository_impl_test.dart
+++ b/test/features/financial_modeling/data/repositories/financial_repository_impl_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:saas_metrics/features/financial_modeling/data/repositories/financial_repository_impl.dart';
+import 'package:saas_metrics/features/financial_modeling/domain/entities/financial_scenario.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  late FinancialRepositoryImpl repository;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    repository = FinancialRepositoryImpl();
+  });
+
+  group('FinancialRepositoryImpl', () {
+    final tScenario = FinancialScenario(
+      id: '1',
+      name: 'Test Scenario',
+      startDate: DateTime(2023, 1, 1),
+      durationMonths: 12,
+      parameters: const {'test': 1},
+    );
+
+    test('should save and retrieve scenarios', () async {
+      // Act
+      await repository.saveScenario(tScenario);
+      final result = await repository.getAllScenarios();
+
+      // Assert
+      expect(result.length, 1);
+      expect(result.first.id, tScenario.id);
+      expect(result.first.name, tScenario.name);
+      
+      // Verify specific values
+      expect(result.first.startDate, tScenario.startDate);
+      expect(result.first.parameters, tScenario.parameters);
+    });
+
+    test('should update existing scenario', () async {
+      // Arrange
+      await repository.saveScenario(tScenario);
+      final updatedScenario = tScenario.copyWith(name: 'Updated Name');
+
+      // Act
+      await repository.saveScenario(updatedScenario);
+      final result = await repository.getAllScenarios();
+
+      // Assert
+      expect(result.length, 1);
+      expect(result.first.name, 'Updated Name');
+    });
+
+    test('should delete scenario', () async {
+      // Arrange
+      await repository.saveScenario(tScenario);
+
+      // Act
+      await repository.deleteScenario(tScenario.id);
+      final result = await repository.getAllScenarios();
+
+      // Assert
+      expect(result, isEmpty);
+    });
+
+    test('should return empty list when no data', () async {
+      // Act
+      final result = await repository.getAllScenarios();
+
+      // Assert
+      expect(result, isEmpty);
+    });
+  });
+}

--- a/test/features/financial_modeling/presentation/widgets/saved_scenarios_dialog_test.dart
+++ b/test/features/financial_modeling/presentation/widgets/saved_scenarios_dialog_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:saas_metrics/features/financial_modeling/domain/entities/financial_scenario.dart';
+import 'package:saas_metrics/features/financial_modeling/domain/repositories/financial_repository.dart';
+import 'package:saas_metrics/features/financial_modeling/presentation/providers/financial_projections_provider.dart';
+import 'package:saas_metrics/features/financial_modeling/presentation/providers/financial_repository_provider.dart';
+import 'package:saas_metrics/features/financial_modeling/presentation/widgets/saved_scenarios_dialog.dart';
+
+// Mocks
+class MockFinancialRepository implements FinancialRepository {
+  List<FinancialScenario> scenarios = [
+    FinancialScenario(
+      id: '1',
+      name: 'Scenario 1',
+      startDate: DateTime(2023, 1, 1),
+      durationMonths: 12,
+      parameters: {},
+    ),
+    FinancialScenario(
+      id: '2',
+      name: 'Scenario 2',
+      startDate: DateTime(2023, 1, 1),
+      durationMonths: 24,
+      parameters: {},
+    ),
+  ];
+
+  @override
+  Future<List<FinancialScenario>> getAllScenarios() async => scenarios;
+
+  @override
+  Future<FinancialScenario?> getScenario(String id) async =>
+      scenarios.firstWhere((s) => s.id == id);
+
+  @override
+  Future<void> saveScenario(FinancialScenario scenario) async {}
+
+  @override
+  Future<void> deleteScenario(String id) async {
+    scenarios.removeWhere((s) => s.id == id);
+  }
+}
+
+class MockFinancialProjectionsNotifier extends FinancialProjectionsNotifier {
+  FinancialScenario? generatedScenario;
+
+  @override
+  Future<void> generate(FinancialScenario scenario) async {
+    generatedScenario = scenario;
+    state = const AsyncValue.data([]);
+  }
+}
+
+void main() {
+  testWidgets('SavedScenariosDialog lists scenarios and handles actions', (
+    tester,
+  ) async {
+    final mockRepo = MockFinancialRepository();
+    final mockProjections = MockFinancialProjectionsNotifier();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          financialRepositoryProvider.overrideWithValue(mockRepo),
+          financialProjectionsProvider.overrideWith(() => mockProjections),
+        ],
+        child: const MaterialApp(home: Scaffold(body: SavedScenariosDialog())),
+      ),
+    );
+
+    // Allow FutureBuilder to resolve
+    await tester.pumpAndSettle();
+
+    // Verify List
+    expect(find.text('Scenario 1'), findsOneWidget);
+    expect(find.text('Scenario 2'), findsOneWidget);
+    expect(
+      find.textContaining('12 months'),
+      findsOneWidget,
+    ); // Part of subtitle
+    expect(find.textContaining('24 months'), findsOneWidget);
+
+    // Test Load (Tap item)
+    await tester.tap(find.text('Scenario 1'));
+    await tester.pumpAndSettle();
+
+    expect(mockProjections.generatedScenario?.id, '1');
+
+    // Re-pump to test delete (dialog closed on tap, so need to restart or use a different test block)
+    // Actually, let's just create a new test block for delete because the dialog pops on load.
+  });
+
+  testWidgets('SavedScenariosDialog functionality handles delete', (
+    tester,
+  ) async {
+    final mockRepo = MockFinancialRepository();
+    // Ensure we have data
+    expect(mockRepo.scenarios.length, 2);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [financialRepositoryProvider.overrideWithValue(mockRepo)],
+        child: const MaterialApp(home: Scaffold(body: SavedScenariosDialog())),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Test Delete (Scenario 1)
+    await tester.tap(find.widgetWithIcon(IconButton, Icons.delete).first);
+    await tester.pumpAndSettle();
+
+    // Verify it's gone from UI
+    expect(find.text('Scenario 1'), findsNothing);
+    expect(find.text('Scenario 2'), findsOneWidget);
+
+    // Check internal state of mock if possible, but UI check is usually enough
+  });
+}

--- a/test/features/financial_modeling/presentation/widgets/simulation_dialog_test.dart
+++ b/test/features/financial_modeling/presentation/widgets/simulation_dialog_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:saas_metrics/features/financial_modeling/domain/entities/financial_scenario.dart';
+import 'package:saas_metrics/features/financial_modeling/domain/entities/monthly_financial_record.dart';
+import 'package:saas_metrics/features/financial_modeling/presentation/providers/financial_projections_provider.dart';
+import 'package:saas_metrics/features/financial_modeling/presentation/widgets/simulation_dialog.dart';
+
+// Mock Notifier
+class MockFinancialProjectionsNotifier extends FinancialProjectionsNotifier {
+  FinancialScenario? lastScenario;
+
+  @override
+  Future<void> generate(FinancialScenario scenario) async {
+    lastScenario = scenario;
+    // Simulate empty result
+    state = const AsyncValue.data([]);
+  }
+}
+
+void main() {
+  testWidgets('SimulationDialog validates and submits correct values', (tester) async {
+    final mockNotifier = MockFinancialProjectionsNotifier();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          financialProjectionsProvider.overrideWith(() => mockNotifier),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(
+            body: SimulationDialog(),
+          ),
+        ),
+      ),
+    );
+
+    // Verify initial values
+    expect(find.text('100'), findsOneWidget); // Starting Customers
+    expect(find.text('10'), findsOneWidget); // New / Month
+    expect(find.text('1000.0'), findsOneWidget); // Marketing Spend
+
+    // Enter new values
+    await tester.enterText(find.widgetWithText(TextFormField, 'New / Month'), '20');
+    await tester.enterText(find.widgetWithText(TextFormField, 'Marketing Spend (Monthly)'), '2000.0');
+    await tester.enterText(find.widgetWithText(TextFormField, 'Tax Rate'), '0.20');
+
+    // Run Simulation
+    await tester.tap(find.text('Run Simulation'));
+    await tester.pumpAndSettle();
+
+    // Verify Generate was called with correct values
+    expect(mockNotifier.lastScenario, isNotNull);
+    final params = mockNotifier.lastScenario!.parameters;
+    
+    expect(params['new_customers_monthly'], 20);
+    expect(params['marketing_spend'], 2000.0);
+    expect(params['tax_rate'], 0.20);
+  });
+}


### PR DESCRIPTION
Closes #10

## Changes
- **Enhanced Input Configuration**: Added `SimulationDialog` inputs for Marketing Spend, OpEx, Tax Rate, etc.
- **Scenario Persistence**: Implemented `FinancialRepository` using SharedPreferences to Save/Load/Delete scenarios.
- **UI**: Added Saved Scenarios FAB to `DashboardPage`.

## Verification
- Added `testing` for repository and dialog widgets.
- Manual verification of Save/Load flow.